### PR TITLE
Use embedded binaries, add check workflow, improve README

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -1,36 +1,36 @@
 name: Check
 
 on:
-    pull_request:
-        branches:
-            - main
-    push:
-        branches:
-            - main
+  pull_request:
+    branches:
+      - main
+  push:
+    branches:
+      - main
 
 jobs:
-    check:
-        runs-on: ubuntu-latest
+  check:
+    runs-on: ubuntu-latest
 
-        steps:
-            - name: Checkout
-              uses: actions/checkout@v4
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
 
-            - name: Install Flutter
-              uses: subosito/flutter-action@v2
-              with:
-                  cache: true
-                  channel: stable
+      - name: Install Flutter
+        uses: subosito/flutter-action@v2
+        with:
+          cache: true
+          channel: stable
 
-            - name: Install dependencies
-              run: flutter pub get
+      - name: Install dependencies
+        run: flutter pub get
 
-            - name: Verify formatting
-              run: dart format --set-exit-if-changed bin
+      - name: Verify formatting
+        run: dart format --set-exit-if-changed bin
 
-            - name: Analyze
-              run: flutter analyze
+      - name: Analyze
+        run: flutter analyze
 
-            - name: Dry run pub publish
-              # We don't want it to fail the CI, it's just to see how would `pub publish` behave.
-              run: dart pub publish --dry-run || true
+      - name: Dry run pub publish
+        # We don't want it to fail the CI, it's just to see how would `pub publish` behave.
+        run: dart pub publish --dry-run || true

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -26,7 +26,7 @@ jobs:
               run: flutter pub get
 
             - name: Verify formatting
-              run: dart format --set-exit-if-changed .
+              run: dart format --set-exit-if-changed bin
 
             - name: Analyze
               run: flutter analyze

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -1,0 +1,34 @@
+name: Prepare
+
+on:
+    pull_request:
+        branches: [main]
+    push:
+        branches: [main]
+
+jobs:
+    format:
+        runs-on: ubuntu-latest
+
+        steps:
+            - name: Checkout
+              uses: actions/checkout@v4
+
+            - name: Install Flutter
+              uses: subosito/flutter-action@v2
+              with:
+                  flutter-version: latest
+                  channel: stable
+
+            - name: Install dependencies
+              run: flutter pub get
+
+            - name: Verify formatting
+              run: dart format --set-exit-if-changed .
+
+            - name: Analyze
+              run: flutter analyze
+
+            - name: Dry run pub publish
+              # We don't want it to fail the CI, it's just to see how would `pub publish` behave.
+              run: dart pub publish --dry-run || true

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -9,7 +9,7 @@ on:
             - main
 
 jobs:
-    format:
+    check:
         runs-on: ubuntu-latest
 
         steps:
@@ -19,7 +19,7 @@ jobs:
             - name: Install Flutter
               uses: subosito/flutter-action@v2
               with:
-                  flutter-version: latest
+                  cache: true
                   channel: stable
 
             - name: Install dependencies

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -1,10 +1,12 @@
-name: Prepare
+name: Check
 
 on:
     pull_request:
-        branches: [main]
+        branches:
+            - main
     push:
-        branches: [main]
+        branches:
+            - main
 
 jobs:
     format:

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -23,5 +23,32 @@ jobs:
         with:
           sdk: 3.4
 
+      - name: Download cwebp
+        run:
+          mkdir tmp
+          cd tmp
+
+          curl https://storage.googleapis.com/downloads.webmproject.org/releases/webp/libwebp-1.4.0-windows-x64.zip
+          curl https://storage.googleapis.com/downloads.webmproject.org/releases/webp/libwebp-1.4.0-rc1-mac-x86-64.tar.gz
+          curl https://storage.googleapis.com/downloads.webmproject.org/releases/webp/libwebp-1.4.0-rc1-mac-arm64.tar.gz
+          curl https://storage.googleapis.com/downloads.webmproject.org/releases/webp/libwebp-1.4.0-linux-x86-64.tar.gz
+          curl https://storage.googleapis.com/downloads.webmproject.org/releases/webp/libwebp-1.4.0-linux-aarch64.tar.gz
+
+          tar -zf libwebp-1.4.0-windows-x64.zip
+          tar -xzf libwebp-1.4.0-rc1-mac-x86-64.tar.gz
+          tar -xzf libwebp-1.4.0-rc1-mac-arm64.tar.gz
+          tar -xzf libwebp-1.4.0-linux-x86-64.tar.gz
+          tar -xzf libwebp-1.4.0-linux-aarch64.tar.gz
+
+          cd ..
+
+          mv tmp/libwebp-1.4.0-windows-x64/libwebp-1.4.0-windows-x64/bin/cwebp.exe windows-x64/
+          mv tmp/libwebp-1.4.0-rc1-mac-x86-64/libwebp-1.4.0-rc1-mac-x86-64/bin/cwebp.exe mac-x86-64/
+          mv tmp/libwebp-1.4.0-rc1-mac-arm64/libwebp-1.4.0-rc1-mac-arm64/bin/cwebp.exe mac-arm64/
+          mv tmp/libwebp-1.4.0-linux-x86-64/libwebp-1.4.0-linux-x86-64/bin/cwebp.exe linux-x86-64/
+          mv tmp/libwebp-1.4.0-linux-aarch64/libwebp-1.4.0-linux-aarch64/bin/cwebp.exe linux-aarch64/
+
+          rm -r tmp
+
       - name: Publish and release
         uses: leancodepl/mobile-tools/.github/actions/pub-release@pub-release-v1

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -10,6 +10,9 @@ jobs:
 
     runs-on: ubuntu-latest
 
+    env:
+      cwebp-version: 1.4.0
+
     permissions:
       id-token: write
       contents: write
@@ -28,11 +31,11 @@ jobs:
           mkdir tmp
           cd tmp
 
-          curl https://storage.googleapis.com/downloads.webmproject.org/releases/webp/libwebp-1.4.0-windows-x64.zip -o windows-x64.zip
-          curl https://storage.googleapis.com/downloads.webmproject.org/releases/webp/libwebp-1.4.0-rc1-mac-x86-64.tar.gz -o mac-x86-64.tar.gz
-          curl https://storage.googleapis.com/downloads.webmproject.org/releases/webp/libwebp-1.4.0-rc1-mac-arm64.tar.gz -o mac-arm64.tar.gz
-          curl https://storage.googleapis.com/downloads.webmproject.org/releases/webp/libwebp-1.4.0-linux-x86-64.tar.gz -o linux-x86-64.tar.gz
-          curl https://storage.googleapis.com/downloads.webmproject.org/releases/webp/libwebp-1.4.0-linux-aarch64.tar.gz -o linux-aarch64.tar.gz
+          curl https://storage.googleapis.com/downloads.webmproject.org/releases/webp/libwebp-${{env.cwebp-version}}-windows-x64.zip -o windows-x64.zip
+          curl https://storage.googleapis.com/downloads.webmproject.org/releases/webp/libwebp-${{env.cwebp-version}}-rc1-mac-x86-64.tar.gz -o mac-x86-64.tar.gz
+          curl https://storage.googleapis.com/downloads.webmproject.org/releases/webp/libwebp-${{env.cwebp-version}}-rc1-mac-arm64.tar.gz -o mac-arm64.tar.gz
+          curl https://storage.googleapis.com/downloads.webmproject.org/releases/webp/libwebp-${{env.cwebp-version}}-linux-x86-64.tar.gz -o linux-x86-64.tar.gz
+          curl https://storage.googleapis.com/downloads.webmproject.org/releases/webp/libwebp-${{env.cwebp-version}}-linux-aarch64.tar.gz -o linux-aarch64.tar.gz
 
           tar -xzf windows-x64.zip
           tar -xzf mac-x86-64.tar.gz

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -43,10 +43,10 @@ jobs:
           cd ..
 
           mv tmp/libwebp-1.4.0-windows-x64/libwebp-1.4.0-windows-x64/bin/cwebp.exe windows-x64/
-          mv tmp/libwebp-1.4.0-rc1-mac-x86-64/libwebp-1.4.0-rc1-mac-x86-64/bin/cwebp.exe mac-x86-64/
-          mv tmp/libwebp-1.4.0-rc1-mac-arm64/libwebp-1.4.0-rc1-mac-arm64/bin/cwebp.exe mac-arm64/
-          mv tmp/libwebp-1.4.0-linux-x86-64/libwebp-1.4.0-linux-x86-64/bin/cwebp.exe linux-x86-64/
-          mv tmp/libwebp-1.4.0-linux-aarch64/libwebp-1.4.0-linux-aarch64/bin/cwebp.exe linux-aarch64/
+          mv tmp/libwebp-1.4.0-rc1-mac-x86-64/libwebp-1.4.0-rc1-mac-x86-64/bin/cwebp mac-x86-64/
+          mv tmp/libwebp-1.4.0-rc1-mac-arm64/libwebp-1.4.0-rc1-mac-arm64/bin/cwebp mac-arm64/
+          mv tmp/libwebp-1.4.0-linux-x86-64/libwebp-1.4.0-linux-x86-64/bin/cwebp linux-x86-64/
+          mv tmp/libwebp-1.4.0-linux-aarch64/libwebp-1.4.0-linux-aarch64/bin/cwebp linux-aarch64/
 
           rm -r tmp
 

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -28,25 +28,31 @@ jobs:
           mkdir tmp
           cd tmp
 
-          curl https://storage.googleapis.com/downloads.webmproject.org/releases/webp/libwebp-1.4.0-windows-x64.zip
-          curl https://storage.googleapis.com/downloads.webmproject.org/releases/webp/libwebp-1.4.0-rc1-mac-x86-64.tar.gz
-          curl https://storage.googleapis.com/downloads.webmproject.org/releases/webp/libwebp-1.4.0-rc1-mac-arm64.tar.gz
-          curl https://storage.googleapis.com/downloads.webmproject.org/releases/webp/libwebp-1.4.0-linux-x86-64.tar.gz
-          curl https://storage.googleapis.com/downloads.webmproject.org/releases/webp/libwebp-1.4.0-linux-aarch64.tar.gz
+          curl https://storage.googleapis.com/downloads.webmproject.org/releases/webp/libwebp-1.4.0-windows-x64.zip -o windows-x64.zip
+          curl https://storage.googleapis.com/downloads.webmproject.org/releases/webp/libwebp-1.4.0-rc1-mac-x86-64.tar.gz -o mac-x86-64.tar.gz
+          curl https://storage.googleapis.com/downloads.webmproject.org/releases/webp/libwebp-1.4.0-rc1-mac-arm64.tar.gz -o mac-arm64.tar.gz
+          curl https://storage.googleapis.com/downloads.webmproject.org/releases/webp/libwebp-1.4.0-linux-x86-64.tar.gz -o linux-x86-64.tar.gz
+          curl https://storage.googleapis.com/downloads.webmproject.org/releases/webp/libwebp-1.4.0-linux-aarch64.tar.gz -o linux-aarch64.tar.gz
 
-          tar -zf libwebp-1.4.0-windows-x64.zip
-          tar -xzf libwebp-1.4.0-rc1-mac-x86-64.tar.gz
-          tar -xzf libwebp-1.4.0-rc1-mac-arm64.tar.gz
-          tar -xzf libwebp-1.4.0-linux-x86-64.tar.gz
-          tar -xzf libwebp-1.4.0-linux-aarch64.tar.gz
+          tar -xzf windows-x64.zip
+          tar -xzf mac-x86-64.tar.gz
+          tar -xzf mac-arm64.tar.gz
+          tar -xzf linux-x86-64.tar.gz
+          tar -xzf linux-aarch64.tar.gz
 
           cd ..
 
-          mv tmp/libwebp-1.4.0-windows-x64/libwebp-1.4.0-windows-x64/bin/cwebp.exe windows-x64/
-          mv tmp/libwebp-1.4.0-rc1-mac-x86-64/libwebp-1.4.0-rc1-mac-x86-64/bin/cwebp mac-x86-64/
-          mv tmp/libwebp-1.4.0-rc1-mac-arm64/libwebp-1.4.0-rc1-mac-arm64/bin/cwebp mac-arm64/
-          mv tmp/libwebp-1.4.0-linux-x86-64/libwebp-1.4.0-linux-x86-64/bin/cwebp linux-x86-64/
-          mv tmp/libwebp-1.4.0-linux-aarch64/libwebp-1.4.0-linux-aarch64/bin/cwebp linux-aarch64/
+          mkdir windows-x64
+          mkdir mac-x86-64
+          mkdir mac-arm64
+          mkdir linux-x86-64
+          mkdir linux-aarch64
+
+          mv tmp/libwebp-1.4.0-windows-x64/bin/cwebp.exe windows-x64/cwebp.exe
+          mv tmp/libwebp-1.4.0-rc1-mac-x86-64/bin/cwebp mac-x86-64/cwebp
+          mv tmp/libwebp-1.4.0-rc1-mac-arm64/bin/cwebp mac-arm64/cwebp
+          mv tmp/libwebp-1.4.0-linux-x86-64/bin/cwebp linux-x86-64/cwebp
+          mv tmp/libwebp-1.4.0-linux-aarch64/bin/cwebp linux-aarch64/cwebp
 
           rm -r tmp
 

--- a/README.md
+++ b/README.md
@@ -3,7 +3,15 @@
 [![webp pub.dev badge][pub-badge]][pub-badge-link]
 [![][build-badge]][build-badge-link]
 
-Asset transformer for converting images into WebP files. Read more about Asset transformers in Flutter in the [documentation](https://docs.flutter.dev/ui/assets/asset-transformation).
+Asset transformer for converting images into WebP files.
+
+## Supported architectures
+
+- windows_x64
+- macos_x64
+- macos_arm64
+- linux_x64
+- linux_arm64
 
 ## Install package
 
@@ -60,6 +68,9 @@ Here are some commonly used parameters for cwebp:
 - `-s`, `--size`: Set the target size for the output image. The value should be in bytes. For example, `--size=500000`.
 
 For a complete list of parameters and their descriptions, please refer to the [cwebp documentation](https://developers.google.com/speed/webp/docs/cwebp).
+
+## Learn more
+- [Asset transformers in Flutter](https://docs.flutter.dev/ui/assets/asset-transformation)
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -1,8 +1,9 @@
 # webp
 
 [![webp pub.dev badge][pub-badge]][pub-badge-link]
+[![][build-badge]][build-badge-link]
 
-Asset transformer for converting images into WebP files.
+Asset transformer for converting images into WebP files. Read more about Asset transformers in Flutter in the [documentation](https://docs.flutter.dev/ui/assets/asset-transformation).
 
 ## Install package
 
@@ -37,7 +38,7 @@ flutter:
           args: ['--quality=65', '--hint=graph', '--af']
 ```
 
-By default, the package runs the embedded precompiled cwebp binary. You can use the one specified in your `$PATH` by adding the `--from_path` flag.
+By default, the package runs the embedded precompiled cwebp binary. You can use the one specified in your `$PATH` by adding the `--from_path` flag. On how to install cwebp see [Optional cwebp installation](#optional_cwebp_installation).
 
 ```yaml
 flutter:
@@ -47,6 +48,16 @@ flutter:
         - package: webp
           args: ['--from_path']
 ```
+
+## <a id="optional_cwebp_installation"></a> Optional cwebp installation
+
+### Option 1: Download precompiled binaries from Google
+
+Follow the instructions at [https://developers.google.com/speed/webp/docs/precompiled](https://developers.google.com/speed/webp/docs/precompiled) to download and install the precompiled binaries for cwebp.
+
+### Option 2: Install using Homebrew (macOS)
+
+If you are using macOS and have Homebrew installed, you can install cwebp using the following command: `brew install webp`
 
 ## cwebp parameters
 
@@ -73,3 +84,5 @@ For a complete list of parameters and their descriptions, please refer to the [c
 
 [pub-badge]: https://img.shields.io/pub/v/webp
 [pub-badge-link]: https://pub.dev/packages/webp
+[build-badge]: https://img.shields.io/github/actions/workflow/status/leancodepl/flutter_webp/check.yml?branch=main
+[build-badge-link]: https://github.com/leancodepl/flutter_webp/actions/workflows/check.yml

--- a/README.md
+++ b/README.md
@@ -5,14 +5,6 @@
 
 Asset transformer for converting images into WebP files.
 
-## Supported architectures
-
-- windows_x64
-- macos_x64
-- macos_arm64
-- linux_x64
-- linux_arm64
-
 ## Install package
 
 ```
@@ -21,7 +13,7 @@ flutter pub add webp --dev
 
 ## Package usage
 
-Add to your pubspec.yaml
+Add to your `pubspec.yaml`.
 
 ### Default usage
 
@@ -68,6 +60,17 @@ Here are some commonly used parameters for cwebp:
 - `-s`, `--size`: Set the target size for the output image. The value should be in bytes. For example, `--size=500000`.
 
 For a complete list of parameters and their descriptions, please refer to the [cwebp documentation](https://developers.google.com/speed/webp/docs/cwebp).
+
+## Supported architectures
+
+The package provides cwebp binaries for the following architectures:
+- windows-x64,
+- macos-x64,
+- macos-arm64,
+- linux-x64,
+- linux-arm64.
+
+Note: You can still use the package on other architectures with cwebp from your `$PATH`.
 
 ## Learn more
 - [Asset transformers in Flutter](https://docs.flutter.dev/ui/assets/asset-transformation)

--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ flutter:
           args: ['--quality=65', '--hint=graph', '--af']
 ```
 
-By default, the package runs the embedded precompiled cwebp binary. You can use the one specified in your `$PATH` by adding the `--from_path` flag. On how to install cwebp see [Optional cwebp installation](#optional_cwebp_installation).
+By default, the package runs the embedded precompiled cwebp binary. You can use the one specified in your `$PATH` by adding the `--from_path` flag.
 
 ```yaml
 flutter:
@@ -48,16 +48,6 @@ flutter:
         - package: webp
           args: ['--from_path']
 ```
-
-## <a id="optional_cwebp_installation"></a> Optional cwebp installation
-
-### Option 1: Download precompiled binaries from Google
-
-Follow the instructions at [https://developers.google.com/speed/webp/docs/precompiled](https://developers.google.com/speed/webp/docs/precompiled) to download and install the precompiled binaries for cwebp.
-
-### Option 2: Install using Homebrew (macOS)
-
-If you are using macOS and have Homebrew installed, you can install cwebp using the following command: `brew install webp`
 
 ## cwebp parameters
 

--- a/README.md
+++ b/README.md
@@ -84,5 +84,5 @@ For a complete list of parameters and their descriptions, please refer to the [c
 
 [pub-badge]: https://img.shields.io/pub/v/webp
 [pub-badge-link]: https://pub.dev/packages/webp
-[build-badge]: https://img.shields.io/github/actions/workflow/status/leancodepl/flutter_webp/check.yml?branch=main
+[build-badge]: https://img.shields.io/github/actions/workflow/status/leancodepl/flutter_webp/check.yml
 [build-badge-link]: https://github.com/leancodepl/flutter_webp/actions/workflows/check.yml

--- a/README.md
+++ b/README.md
@@ -1,15 +1,8 @@
 # webp
 
+[![webp pub.dev badge][pub-badge]][pub-badge-link]
+
 Asset transformer for converting images into WebP files.
-
-## Install cwebp
-### Option 1: Download precompiled binaries from Google
-
-Follow the instructions at [https://developers.google.com/speed/webp/docs/precompiled](https://developers.google.com/speed/webp/docs/precompiled) to download and install the precompiled binaries for cwebp.
-
-### Option 2: Install using Homebrew (macOS)
-
-If you are using macOS and have Homebrew installed, you can install cwebp using the following command: `brew install webp`
 
 ## Install package
 
@@ -21,7 +14,7 @@ flutter pub add webp --dev
 
 Add to your pubspec.yaml
 
-#### Default usage
+### Default usage
 
 If run without additional arguments, the default value of the quality parameter = 75 with lossy compression will be used.
 
@@ -33,7 +26,7 @@ flutter:
         - package: webp
 ```
 
-#### Usage with params
+### Usage with params
 
 ```yaml
 flutter:
@@ -42,6 +35,17 @@ flutter:
       transformers:
         - package: webp
           args: ['--quality=65', '--hint=graph', '--af']
+```
+
+By default, the package runs the embedded precompiled cwebp binary. You can use the one specified in your `$PATH` by adding the `--from_path` flag.
+
+```yaml
+flutter:
+  assets:
+    - path: assets/logo.jpg
+      transformers:
+        - package: webp
+          args: ['--from_path']
 ```
 
 ## cwebp parameters
@@ -55,3 +59,17 @@ Here are some commonly used parameters for cwebp:
 - `-s`, `--size`: Set the target size for the output image. The value should be in bytes. For example, `--size=500000`.
 
 For a complete list of parameters and their descriptions, please refer to the [cwebp documentation](https://developers.google.com/speed/webp/docs/cwebp).
+
+---
+
+<p align="center">
+   <a href="https://leancode.co/?utm_source=readme&utm_medium=bloc_lens_package">
+      <img alt="LeanCode" src="https://leancodepublic.blob.core.windows.net/public/wide.png" width="300"/>
+   </a>
+   <p align="center">
+   Built with ☕️ by <a href="https://leancode.co/?utm_source=readme&utm_medium=bloc_lens_package">LeanCode</a>
+   </p>
+</p>
+
+[pub-badge]: https://img.shields.io/pub/v/webp
+[pub-badge-link]: https://pub.dev/packages/webp

--- a/bin/webp.dart
+++ b/bin/webp.dart
@@ -254,11 +254,11 @@ void logUsage(ArgParser argParser) {
   log(argParser.usage);
 }
 
-Future<String> getPath() async {
+Future<String> getPackageCwebpPath() async {
   if (!architectures.keys.contains(Abi.current())) {
-    final m1 = 'Architecture ${Abi.current()} not spported.';
-    const m2 = 'Supported architectures are:';
-    stderr.write('$m1 $m2 ${architectures.keys}');
+    final msg1 = 'Architecture ${Abi.current()} not supported.';
+    final msg2 = 'Supported architectures are: ${architectures.keys}.';
+    stderr.write('$msg1 $msg2');
     exit(1);
   }
 
@@ -290,7 +290,7 @@ Future<void> convertToWebP(
   if (fromPath) {
     path = 'cwebp';
   } else {
-    path = p.join(await getPath(), 'cwebp');
+    path = p.join(await getPackageCwebpPath(), 'cwebp');
   }
 
   try {

--- a/bin/webp.dart
+++ b/bin/webp.dart
@@ -10,6 +10,14 @@ import 'package:path/path.dart' as p;
 
 const version = '0.1.0';
 
+const architectures = {
+  Abi.windowsX64: 'windows-x64',
+  Abi.macosX64: 'mac-x86-64',
+  Abi.macosArm64: 'mac-arm64',
+  Abi.linuxX64: 'linux-x86-64',
+  Abi.linuxArm64: 'linux-aarch64',
+};
+
 ArgParser buildParser() {
   return ArgParser()
 
@@ -42,6 +50,12 @@ ArgParser buildParser() {
       mandatory: true,
       abbr: 'o',
       help: 'Output WebP file.',
+    )
+    ..addFlag(
+      'architectures',
+      abbr: 'arch',
+      negatable: false,
+      help: 'List supported architectures',
     )
     ..addFlag(
       'from_path',
@@ -242,18 +256,10 @@ void logUsage(ArgParser argParser) {
 }
 
 Future<String> getPath() async {
-  final architectures = [
-    Abi.windowsX64,
-    Abi.macosX64,
-    Abi.macosArm64,
-    Abi.linuxX64,
-    Abi.linuxArm64,
-  ];
-
-  if (!architectures.contains(Abi.current())) {
+  if (!architectures.keys.contains(Abi.current())) {
     final m1 = 'Architecture ${Abi.current()} not spported.';
     const m2 = 'Supported architectures are:';
-    stderr.write('$m1 $m2 $architectures');
+    stderr.write('$m1 $m2 ${architectures.keys}');
     exit(1);
   }
 
@@ -271,7 +277,7 @@ Future<String> getPath() async {
     exit(1);
   }
 
-  return package.packageUriRoot.path;
+  return p.join(p.fromUri(package.root), architectures[Abi.current()]);
 }
 
 Future<void> convertToWebP(
@@ -317,6 +323,10 @@ Future<void> main(List<String> arguments) async {
     }
     if (results.wasParsed('version')) {
       log('webp version: $version');
+      return;
+    }
+    if (results.wasParsed('architectures')) {
+      log('Supported architectures: ${architectures.keys}');
       return;
     }
     if (results.wasParsed('verbose')) {

--- a/bin/webp.dart
+++ b/bin/webp.dart
@@ -53,7 +53,6 @@ ArgParser buildParser() {
     )
     ..addFlag(
       'architectures',
-      abbr: 'arch',
       negatable: false,
       help: 'List supported architectures',
     )

--- a/bin/webp.dart
+++ b/bin/webp.dart
@@ -42,8 +42,9 @@ ArgParser buildParser() {
       abbr: 'o',
       help: 'Output WebP file.',
     )
-    ..addOption(
+    ..addFlag(
       'from_path',
+      negatable: false,
       help: r'Use a cwebp converter from the $PATH.',
     )
     ..addFlag(

--- a/bin/webp.dart
+++ b/bin/webp.dart
@@ -8,9 +8,9 @@ import 'package:path/path.dart' as p;
 
 /// All cwebp options are listed: https://developers.google.com/speed/webp/docs/cwebp
 
-const version = '0.1.0';
+const _version = '0.1.0';
 
-const architectures = {
+const _architectures = {
   Abi.windowsX64: 'windows-x64',
   Abi.macosX64: 'mac-x86-64',
   Abi.macosArm64: 'mac-arm64',
@@ -18,7 +18,7 @@ const architectures = {
   Abi.linuxArm64: 'linux-aarch64',
 };
 
-ArgParser buildParser() {
+ArgParser _buildParser() {
   return ArgParser()
 
     /// Basic Options
@@ -247,18 +247,18 @@ ArgParser buildParser() {
     );
 }
 
-void logUsage(ArgParser argParser) {
+void _logUsage(ArgParser argParser) {
   log(
     'Usage: dart webp.dart <flags> [arguments]',
   );
   log(argParser.usage);
 }
 
-Future<String> getPackageCwebpPath() async {
-  if (!architectures.keys.contains(Abi.current())) {
-    final msg1 = 'Architecture ${Abi.current()} not supported.';
-    final msg2 = 'Supported architectures are: ${architectures.keys}.';
-    stderr.write('$msg1 $msg2');
+Future<String> _getPackageCwebpPath() async {
+  if (!_architectures.keys.contains(Abi.current())) {
+    stderr.write(
+      'Architecture ${Abi.current()} not supported. Supported architectures are: ${_architectures.keys}.',
+    );
     exit(1);
   }
 
@@ -276,10 +276,10 @@ Future<String> getPackageCwebpPath() async {
     exit(1);
   }
 
-  return p.join(p.fromUri(package.root), architectures[Abi.current()]);
+  return p.join(p.fromUri(package.root), _architectures[Abi.current()]);
 }
 
-Future<void> convertToWebP(
+Future<void> _convertToWebP(
   String input,
   String output,
   List<String> options, {
@@ -290,7 +290,7 @@ Future<void> convertToWebP(
   if (fromPath) {
     path = 'cwebp';
   } else {
-    path = p.join(await getPackageCwebpPath(), 'cwebp');
+    path = p.join(await _getPackageCwebpPath(), 'cwebp');
   }
 
   try {
@@ -307,7 +307,7 @@ Future<void> convertToWebP(
 }
 
 Future<void> main(List<String> arguments) async {
-  final argParser = buildParser();
+  final argParser = _buildParser();
   final options = <String>[];
   try {
     final results = argParser.parse(arguments);
@@ -317,15 +317,15 @@ Future<void> main(List<String> arguments) async {
     // Process the parsed arguments.
     // Basic Options
     if (results.wasParsed('help')) {
-      logUsage(argParser);
+      _logUsage(argParser);
       return;
     }
     if (results.wasParsed('version')) {
-      log('webp version: $version');
+      log('webp version: $_version');
       return;
     }
     if (results.wasParsed('architectures')) {
-      log('Supported architectures: ${architectures.keys}');
+      log('Supported architectures: ${_architectures.keys}');
       return;
     }
     if (results.wasParsed('verbose')) {
@@ -494,7 +494,7 @@ Future<void> main(List<String> arguments) async {
 
     // Process the parsed arguments.
     if (results.wasParsed('input') && results.wasParsed('output')) {
-      await convertToWebP(
+      await _convertToWebP(
         results['input'] as String,
         results['output'] as String,
         options,
@@ -507,6 +507,6 @@ Future<void> main(List<String> arguments) async {
     // log usage information if an invalid argument was provided.
     log(e.message);
     log('');
-    logUsage(argParser);
+    _logUsage(argParser);
   }
 }

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -295,7 +295,7 @@ packages:
     source: hosted
     version: "2.1.0"
   path:
-    dependency: transitive
+    dependency: "direct main"
     description:
       name: path
       sha256: "087ce49c3f0dc39180befefc60fdb4acd8f8620e5682fe2476afd0b3688bb4af"

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -287,7 +287,7 @@ packages:
     source: hosted
     version: "2.0.2"
   package_config:
-    dependency: transitive
+    dependency: "direct main"
     description:
       name: package_config
       sha256: "1c5b77ccc91e4823a5af61ee74e6b972db1ef98c2ff5a18d3161c982a55448bd"

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -11,6 +11,7 @@ environment:
 
 dependencies:
   args: ^2.4.2
+  path: ^1.9.0
 
 dev_dependencies:
   leancode_lint: ^12.0.0

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -11,6 +11,7 @@ environment:
 
 dependencies:
   args: ^2.4.2
+  package_config: ^2.1.0
   path: ^1.9.0
 
 dev_dependencies:


### PR DESCRIPTION
1. Use embedded binaries:
- before: a cwebp binary required in the project directory
- now: cwebp binaries embedded in the package, also possibility to use cwebp from the `$PATH`

2.  Add `check.yml` workflow for every PR/push to `main`
-  verify formatting
- analyze
- dry run pub publish

3. Improve `README`
- use badges and a footer
- explain how to use cwebp from the `$PATH`
- remove the cwebp installation guide