### PR TITLE
Remove --dev from install package guide

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ Asset transformer for converting images into WebP files.
 ## Install package
 
 ```
-flutter pub add webp --dev
+flutter pub add webp
 ```
 
 ## Package usage

--- a/bin/webp.dart
+++ b/bin/webp.dart
@@ -8,7 +8,7 @@ import 'package:path/path.dart' as p;
 
 /// All cwebp options are listed: https://developers.google.com/speed/webp/docs/cwebp
 
-const _version = '1.0.0';
+const _version = '1.0.0+1';
 
 const _architectures = {
   Abi.windowsX64: 'windows-x64',

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: webp
 description: Asset transformer for converting images into WebP files.
-version: 1.0.0
+version: 1.0.0+1
 repository: https://github.com/leancodepl/flutter_webp
 
 executables:


### PR DESCRIPTION
The package shouldn't be in `dev_dependencies` as it won't work when transforming assets from dependencies.
Example: A depends on B, B depends on webp in `dev_depenencies` -> A's build fails