### PR TITLE
Bump version to 1.0.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,6 @@
 ## 1.0.1
 
 - Fix iOS builds failing on `.DS_Store` files (thanks @mrgnhnt96)
-- Fix `--dev` install guide — package must be a regular dependency for asset transformers to work in dependents (thanks @michalina-majewska)
 - Bump minimum SDK constraint to `^3.11.0`
 - Upgrade `leancode_lint` to `^22.0.0`
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 1.0.1
+
+- Bump minimum SDK constraint to `^3.11.0`
+- Upgrade `leancode_lint` to `^22.0.0`
+
 ## 1.0.0
 
 - Bundle cwebp binaries

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 ## 1.0.1
 
+- Fix iOS builds failing on `.DS_Store` files (thanks @mrgnhnt96)
+- Fix `--dev` install guide — package must be a regular dependency for asset transformers to work in dependents (thanks @michalina-majewska)
 - Bump minimum SDK constraint to `^3.11.0`
 - Upgrade `leancode_lint` to `^22.0.0`
 

--- a/bin/webp.dart
+++ b/bin/webp.dart
@@ -8,7 +8,7 @@ import 'package:path/path.dart' as p;
 
 /// All cwebp options are listed: https://developers.google.com/speed/webp/docs/cwebp
 
-const _version = '1.0.0+1';
+const _version = '1.0.1';
 
 const _architectures = {
   Abi.windowsX64: 'windows-x64',

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: webp
 description: Asset transformer for converting images into WebP files.
-version: 1.0.0+1
+version: 1.0.1
 repository: https://github.com/leancodepl/flutter_webp
 
 executables:


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Bump package version from `1.0.0+1` to `1.0.1` and add changelog entry covering all changes since `1.0.0`.

## Changes

- **`pubspec.yaml`**: Bump version to `1.0.1`
- **`bin/webp.dart`**: Update `_version` constant to `1.0.1`
- **`CHANGELOG.md`**: Add `1.0.1` entry:
  - Fix iOS builds failing on `.DS_Store` files (thanks @mrgnhnt96, PR #16)
  - Bump minimum SDK constraint to `^3.11.0`
  - Upgrade `leancode_lint` to `^22.0.0`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-e5c12040-c5d1-4897-abb3-1e71056d6c2e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-e5c12040-c5d1-4897-abb3-1e71056d6c2e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

